### PR TITLE
Use zone specific source lists

### DIFF
--- a/custom_components/pioneer_async/media_player.py
+++ b/custom_components/pioneer_async/media_player.py
@@ -331,7 +331,7 @@ class PioneerZone(MediaPlayerEntity):
     @property
     def source_list(self):
         """List of available input sources."""
-        return self._pioneer.get_source_list()
+        return self._pioneer.get_source_list(zone=self._zone)
 
     @property
     def media_title(self):


### PR DESCRIPTION
This PR will use zone specific source lists for different zones rather than always showing all configured sources for all zones (on most AVRs HDZone doesn't support analog sources and analog zones don't support HD sources either)

It addresses https://github.com/crowbarz/aiopioneer/issues/10 now that aiopioneer has been updated to 0.3.0.