### PR TITLE
Use discrete debug options

### DIFF
--- a/custom_components/pioneer_async/__init__.py
+++ b/custom_components/pioneer_async/__init__.py
@@ -35,7 +35,6 @@ from .const import (
     OPTIONS_DEFAULTS,
     CONF_SOURCES,
     CONF_PARAMS,
-    CONF_DEBUG_CONFIG,
     ATTR_PIONEER,
     ATTR_COORDINATORS,
     ATTR_DEVICE_INFO,
@@ -46,10 +45,6 @@ from .coordinator import PioneerAVRZoneCoordinator
 from .debug import Debug
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def _debug_atlevel(level: int, category: str = __name__):
-    return Debug.atlevel(None, level, category)
 
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
@@ -131,8 +126,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Pioneer AVR from a config entry."""
-    if CONF_DEBUG_CONFIG in entry.options:
-        Debug.setconfig(None, entry.options[CONF_DEBUG_CONFIG])
+    Debug.setconfig(entry.options)
 
     hass.data.setdefault(DOMAIN, {})
     pioneer_data = {}
@@ -149,7 +143,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     params = {k: entry_options[k] for k in PARAMS_ALL if k in entry_options}
     params |= options.get(CONF_PARAMS, {})
 
-    if _debug_atlevel(9):
+    if Debug.integration:
         _LOGGER.debug(
             ">> async_setup_entry(entry_id=%s, data=%s, options=%s)",
             entry.entry_id,
@@ -302,7 +296,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    if _debug_atlevel(9):
+    if Debug.integration:
         _LOGGER.debug(">> async_unload_entry()")
 
     ## Clear callback references from Pioneer AVR (to allow entities to unload)

--- a/custom_components/pioneer_async/binary_sensor.py
+++ b/custom_components/pioneer_async/binary_sensor.py
@@ -36,15 +36,6 @@ from .entity_base import PioneerEntityBase
 _LOGGER = logging.getLogger(__name__)
 
 
-## Debug levels:
-##  1: service calls
-##  7: callback calls
-##  8: update options flow
-##  9: component load/unload
-def _debug_atlevel(level: int, category: str = __name__):
-    return Debug.atlevel(None, level, category)
-
-
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -56,7 +47,7 @@ async def async_setup_entry(
     options: dict[str, Any] = pioneer_data[ATTR_OPTIONS]
     coordinators: list[PioneerAVRZoneCoordinator] = pioneer_data[ATTR_COORDINATORS]
     zone_device_info: dict[str, DeviceInfo] = pioneer_data[ATTR_DEVICE_INFO]
-    if _debug_atlevel(9):
+    if Debug.integration:
         _LOGGER.debug(
             ">> binary_sensor.async_setup_entry(entry_id=%s, data=%s, options=%s)",
             config_entry.entry_id,

--- a/custom_components/pioneer_async/const.py
+++ b/custom_components/pioneer_async/const.py
@@ -44,11 +44,14 @@ CONF_IGNORE_ZONE_2 = "ignore_zone_2"  ## UI option only
 CONF_IGNORE_ZONE_3 = "ignore_zone_3"  ## UI option only
 CONF_IGNORE_HDZONE = "ignore_hdzone"  ## UI option only
 CONF_QUERY_SOURCES = "query_sources"  ## UI option only, inferred from CONF_SOURCES
-CONF_DEBUG_CONFIG = "debug_config"
+CONF_DEBUG_INTEGRATION = "debug_integration"  # integration load/unload
+CONF_DEBUG_CONFIG_FLOW = "debug_config_flow"  # config and options flow
+CONF_DEBUG_SERVICE = "debug_service"  # service calls
 
 ## Deprecated options
 OLD_CONF_IGNORE_ZONE_H = "ignore_zone_h"  ## deprecated
 OLD_CONF_IGNORE_ZONE_Z = "ignore_zone_z"  ## deprecated
+OLD_CONF_DEBUG_CONFIG = "debug_config"  ## deprecated (not removed)
 OLD_PARAM_HDZONE_SOURCES = "zone_z_sources"  ## deprecated
 OLD_PARAM_DISABLE_AUTO_QUERY = "disable_autoquery"  ## deprecated
 
@@ -73,7 +76,9 @@ OPTIONS_DEFAULTS = {
     CONF_IGNORE_ZONE_2: False,
     CONF_IGNORE_ZONE_3: False,
     CONF_IGNORE_HDZONE: False,
-    CONF_DEBUG_CONFIG: {},
+    CONF_DEBUG_INTEGRATION: False,
+    CONF_DEBUG_CONFIG_FLOW: False,
+    CONF_DEBUG_SERVICE: False,
 }
 OPTIONS_ALL = OPTIONS_DEFAULTS.keys()
 

--- a/custom_components/pioneer_async/debug.py
+++ b/custom_components/pioneer_async/debug.py
@@ -1,7 +1,11 @@
 """Integration debugging."""
 
 import logging
-from .const import DOMAIN
+from .const import (
+    CONF_DEBUG_SERVICE,
+    CONF_DEBUG_CONFIG_FLOW,
+    CONF_DEBUG_INTEGRATION,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -9,25 +13,18 @@ _LOGGER = logging.getLogger(__name__)
 class Debug:
     """Global debug."""
 
-    level = 0  # deprecated
-    config = {}
+    ## Debug classes
+    integration: bool = None
+    config_flow: bool = None
+    service: bool = None
 
-    def setconfig(self, config: dict[str, int] | None) -> None:
+    @staticmethod
+    def setconfig(options: dict[str, int] | None) -> None:
         """Set debug model config."""
-        _LOGGER.debug(">> Debug.setconfig(%s)", config)
-        Debug.config = config
-
-    def atlevel(self, level: int, category_raw: str) -> bool:
-        """Determine if debug is at a level"""
-        if not Debug.config:
-            return False
-        category = category_raw.partition(DOMAIN + ".")[2] or DOMAIN
-        try:
-            debug_level_str = Debug.config.get(category, Debug.config.get("*", 0))
-            debug_level = int(debug_level_str)
-        except ValueError:
-            _LOGGER.error(
-                "invalid debug level for category %s: %s", category, debug_level_str
-            )
-            return None
-        return debug_level >= level
+        _LOGGER.debug(
+            ">> Debug.setconfig(%s)",
+            {k: v for k, v in options.items() if k.startswith("debug_")},
+        )
+        Debug.integration = options.get(CONF_DEBUG_INTEGRATION, False)
+        Debug.config_flow = options.get(CONF_DEBUG_CONFIG_FLOW, False)
+        Debug.service = options.get(CONF_DEBUG_SERVICE, False)

--- a/custom_components/pioneer_async/entity_base.py
+++ b/custom_components/pioneer_async/entity_base.py
@@ -20,10 +20,6 @@ from .debug import Debug
 _LOGGER = logging.getLogger(__name__)
 
 
-def _debug_atlevel(level: int, category: str = __name__):
-    return Debug.atlevel(None, level, category)
-
-
 class PioneerEntityBase(Entity):
     """Pioneer AVR entity base class."""
 
@@ -38,7 +34,7 @@ class PioneerEntityBase(Entity):
         zone: Zone | None = None,
     ) -> None:
         """Initialize the Pioneer AVR entity base class."""
-        if _debug_atlevel(9):
+        if Debug.integration:
             _LOGGER.debug("%s.__init__()", type(self).__name__)
         self.pioneer = pioneer
         self.entry_options = options

--- a/custom_components/pioneer_async/media_player.py
+++ b/custom_components/pioneer_async/media_player.py
@@ -139,15 +139,6 @@ PIONEER_SET_CHANNEL_LEVELS_SCHEMA = {
 # }
 
 
-## Debug levels:
-##  1: service calls
-##  7: callback calls
-##  8: update options flow
-##  9: component load/unload
-def _debug_atlevel(level: int, category: str = __name__):
-    return Debug.atlevel(None, level, category)
-
-
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -159,7 +150,7 @@ async def async_setup_entry(
     options: dict[str, Any] = pioneer_data[ATTR_OPTIONS]
     coordinators: list[PioneerAVRZoneCoordinator] = pioneer_data[ATTR_COORDINATORS]
     zone_device_info = pioneer_data[ATTR_DEVICE_INFO]
-    if _debug_atlevel(9):
+    if Debug.integration:
         _LOGGER.debug(
             ">> media_player.async_setup_entry(entry_id=%s, data=%s, options=%s)",
             config_entry.entry_id,
@@ -277,7 +268,7 @@ class PioneerZone(
         zone: Zone,
     ) -> None:
         """Initialize the Pioneer media_player class."""
-        if _debug_atlevel(9):
+        if Debug.integration:
             _LOGGER.debug("PioneerZone.__init__(%s)", zone)
         super().__init__(pioneer, options, device_info=device_info, zone=zone)
         CoordinatorEntity.__init__(self, coordinator)
@@ -404,7 +395,7 @@ class PioneerZone(
 
     async def async_update(self) -> None:
         """Refresh zone properties on demand."""
-        if _debug_atlevel(8):
+        if Debug.config_flow:
             _LOGGER.debug(">> PioneerZone.async_update(%s)", self.zone)
         return await self.pioneer.update(zone=self.zone)
 
@@ -546,7 +537,7 @@ class PioneerZone(
 
     async def async_set_panel_lock(self, panel_lock: str) -> None:
         """Set AVR panel lock."""
-        if _debug_atlevel(1):
+        if Debug.service:
             _LOGGER.debug(">> PioneerZone.set_panel_lock(panel_lock=%s)", panel_lock)
 
         async def set_panel_lock() -> None:
@@ -556,7 +547,7 @@ class PioneerZone(
 
     async def async_set_remote_lock(self, remote_lock: bool) -> None:
         """Set AVR remote lock."""
-        if _debug_atlevel(1):
+        if Debug.service:
             _LOGGER.debug(">> PioneerZone.set_remote_lock(remote_lock=%s)", remote_lock)
 
         async def set_remote_lock() -> None:
@@ -566,7 +557,7 @@ class PioneerZone(
 
     async def async_set_dimmer(self, dimmer: str) -> None:
         """Set AVR display dimmer."""
-        if _debug_atlevel(1):
+        if Debug.service:
             _LOGGER.debug(">> PioneerZone.set_dimmer(dimmer=%s)", dimmer)
 
         async def set_dimmer() -> None:
@@ -576,7 +567,7 @@ class PioneerZone(
 
     async def async_set_tone_settings(self, tone: str, treble: int, bass: int) -> None:
         """Set AVR tone settings for zone."""
-        if _debug_atlevel(1):
+        if Debug.service:
             _LOGGER.debug(
                 ">> PioneerZone.set_tone_settings(%s, tone=%s, treble=%d, bass=%d)",
                 self.zone,
@@ -592,7 +583,7 @@ class PioneerZone(
 
     async def async_select_tuner_band(self, band: str) -> None:
         """Set AVR tuner band."""
-        if _debug_atlevel(1):
+        if Debug.service:
             _LOGGER.debug(
                 ">> PioneerZone.select_tuner_band(band=%s)",
                 band,
@@ -605,7 +596,7 @@ class PioneerZone(
 
     async def async_set_fm_tuner_frequency(self, frequency: float) -> None:
         """Set AVR AM tuner frequency."""
-        if _debug_atlevel(1):
+        if Debug.service:
             _LOGGER.debug(
                 ">> PioneerZone.set_fm_tuner_frequency(frequency=%f)",
                 frequency,
@@ -618,7 +609,7 @@ class PioneerZone(
 
     async def async_set_am_tuner_frequency(self, frequency: int) -> None:
         """Set AVR AM tuner frequency."""
-        if _debug_atlevel(1):
+        if Debug.service:
             _LOGGER.debug(
                 ">> PioneerZone.set_am_tuner_frequency(frequency=%d)",
                 frequency,
@@ -633,7 +624,7 @@ class PioneerZone(
         """Set AVR tuner preset."""
         tuner_class = kwargs[ATTR_CLASS]  ## workaround for "class" as argument
         preset = kwargs[ATTR_PRESET]
-        if _debug_atlevel(1):
+        if Debug.service:
             _LOGGER.debug(
                 ">> PioneerZone.select_tuner_preset(class=%s, preset=%d)",
                 tuner_class,
@@ -647,7 +638,7 @@ class PioneerZone(
 
     async def async_set_channel_levels(self, channel: str, level: float) -> None:
         """Set AVR level (gain) for amplifier channel in zone."""
-        if _debug_atlevel(1):
+        if Debug.service:
             _LOGGER.debug(
                 ">> PioneerZone.set_channel_levels(%s, channel=%s, level=%f)",
                 self.zone,

--- a/custom_components/pioneer_async/number.py
+++ b/custom_components/pioneer_async/number.py
@@ -47,15 +47,6 @@ TUNER_FREQ_ATTRS = {
 }
 
 
-## Debug levels:
-##  1: service calls
-##  7: callback calls
-##  8: update options flow
-##  9: component load/unload
-def _debug_atlevel(level: int, category: str = __name__):
-    return Debug.atlevel(None, level, category)
-
-
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -67,7 +58,7 @@ async def async_setup_entry(
     options: dict[str, Any] = pioneer_data[ATTR_OPTIONS]
     coordinators: list[PioneerAVRZoneCoordinator] = pioneer_data[ATTR_COORDINATORS]
     zone_device_info: dict[str, DeviceInfo] = pioneer_data[ATTR_DEVICE_INFO]
-    if _debug_atlevel(9):
+    if Debug.integration:
         _LOGGER.debug(
             ">> number.async_setup_entry(entry_id=%s, data=%s, options=%s)",
             config_entry.entry_id,

--- a/custom_components/pioneer_async/select.py
+++ b/custom_components/pioneer_async/select.py
@@ -31,15 +31,6 @@ from .entity_base import PioneerTunerEntity
 _LOGGER = logging.getLogger(__name__)
 
 
-## Debug levels:
-##  1: service calls
-##  7: callback calls
-##  8: update options flow
-##  9: component load/unload
-def _debug_atlevel(level: int, category: str = __name__):
-    return Debug.atlevel(None, level, category)
-
-
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -51,7 +42,7 @@ async def async_setup_entry(
     options: dict[str, Any] = pioneer_data[ATTR_OPTIONS]
     coordinators: list[PioneerAVRZoneCoordinator] = pioneer_data[ATTR_COORDINATORS]
     zone_device_info: dict[str, DeviceInfo] = pioneer_data[ATTR_DEVICE_INFO]
-    if _debug_atlevel(9):
+    if Debug.integration:
         _LOGGER.debug(
             ">> select.async_setup_entry(entry_id=%s, data=%s, options=%s)",
             config_entry.entry_id,

--- a/custom_components/pioneer_async/sensor.py
+++ b/custom_components/pioneer_async/sensor.py
@@ -36,15 +36,6 @@ from .entity_base import PioneerEntityBase
 _LOGGER = logging.getLogger(__name__)
 
 
-## Debug levels:
-##  1: service calls
-##  7: callback calls
-##  8: update options flow
-##  9: component load/unload
-def _debug_atlevel(level: int, category: str = __name__):
-    return Debug.atlevel(None, level, category)
-
-
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -56,7 +47,7 @@ async def async_setup_entry(
     options: dict[str, Any] = pioneer_data[ATTR_OPTIONS]
     coordinators = pioneer_data[ATTR_COORDINATORS]
     zone_device_info: dict[str, DeviceInfo] = pioneer_data[ATTR_DEVICE_INFO]
-    if _debug_atlevel(9):
+    if Debug.integration:
         _LOGGER.debug(
             ">> sensor.async_setup_entry(entry_id=%s, data=%s, options=%s)",
             config_entry.entry_id,

--- a/custom_components/pioneer_async/strings.json
+++ b/custom_components/pioneer_async/strings.json
@@ -118,7 +118,9 @@
                     "debug_updater": "Enable updater task debug logging",
                     "debug_command": "Enable command debug logging",
                     "debug_command_queue": "Enable command queue debug logging",
-                    "debug_config": "Integration debug"
+                    "debug_integration": "Integration load/unload debug logging",
+                    "debug_config_flow": "Integration config/options flow debug logging",
+                    "debug_service": "Integration service call debug logging"
                 },
                 "data_description": {
                     "debug_config": "Additional integration debug configuration. See https://github.com/crowbarz/ha-pioneer_async?tab=readme-ov-file#enabling-debugging for available options"

--- a/custom_components/pioneer_async/translations/en.json
+++ b/custom_components/pioneer_async/translations/en.json
@@ -118,7 +118,9 @@
                     "debug_updater": "Enable updater task debug logging",
                     "debug_command": "Enable command debug logging",
                     "debug_command_queue": "Enable command queue debug logging",
-                    "debug_config": "Integration debug"
+                    "debug_integration": "Integration load/unload debug logging",
+                    "debug_config_flow": "Integration config/options flow debug logging",
+                    "debug_service": "Integration service call debug logging"
                 },
                 "data_description": {
                     "debug_config": "Additional integration debug configuration. See https://github.com/crowbarz/ha-pioneer_async?tab=readme-ov-file#enabling-debugging for available options"


### PR DESCRIPTION
Use discrete debug bools to enable specific debug options instead of a JSON dict. Support enabling/disabling these from the UI. This is more discoverable as all possible debug options are now visible in the UI.