### PR TITLE
Migrate repeat command to aiopioneer retry AVR command

### DIFF
--- a/custom_components/pioneer_async/config_flow.py
+++ b/custom_components/pioneer_async/config_flow.py
@@ -30,6 +30,7 @@ from aiopioneer.params import (
     PARAM_IGNORE_VOLUME_CHECK,
     PARAM_DISABLE_AUTO_QUERY,
     PARAM_ALWAYS_POLL,
+    PARAM_RETRY_COUNT,
     PARAM_DEBUG_LISTENER,
     PARAM_DEBUG_UPDATER,
     PARAM_DEBUG_COMMAND,
@@ -55,7 +56,6 @@ from .const import (
     CONF_TIMEOUT,
     CONF_SOURCES,
     CONF_PARAMS,
-    CONF_REPEAT_COUNT,
     CONF_IGNORE_ZONE_2,
     CONF_IGNORE_ZONE_3,
     CONF_IGNORE_HDZONE,
@@ -534,7 +534,7 @@ class PioneerAVRConfigFlow(
                     )
                 ),
                 vol.Optional(
-                    CONF_REPEAT_COUNT, default=defaults[CONF_REPEAT_COUNT]
+                    PARAM_RETRY_COUNT, default=defaults[PARAM_RETRY_COUNT]
                 ): vol.All(
                     selector.NumberSelector(
                         selector.NumberSelectorConfig(

--- a/custom_components/pioneer_async/const.py
+++ b/custom_components/pioneer_async/const.py
@@ -9,6 +9,7 @@ from aiopioneer.params import (
     PARAM_DISABLE_AUTO_QUERY,
     PARAM_EXTRA_LISTENING_MODES,
     PARAM_SPEAKER_SYSTEM_MODES,
+    PARAM_RETRY_COUNT,
 )
 
 from homeassistant.components.media_player import MediaPlayerDeviceClass
@@ -31,7 +32,7 @@ PLATFORMS_CONFIG_FLOW = [
 ]
 VERSION = "0.11.0"
 CONFIG_ENTRY_VERSION = 5
-CONFIG_ENTRY_VERSION_MINOR = 2
+CONFIG_ENTRY_VERSION_MINOR = 3
 
 DEFAULT_HOST = "avr"
 DEFAULT_NAME = "Pioneer AVR"
@@ -42,7 +43,6 @@ DEFAULT_SOURCES = {}
 
 CONF_SOURCES = "sources"
 CONF_PARAMS = "params"
-CONF_REPEAT_COUNT = "repeat_count"
 CONF_IGNORE_ZONE_2 = "ignore_zone_2"  ## UI option only
 CONF_IGNORE_ZONE_3 = "ignore_zone_3"  ## UI option only
 CONF_IGNORE_HDZONE = "ignore_hdzone"  ## UI option only
@@ -58,6 +58,7 @@ OLD_CONF_IGNORE_ZONE_Z = "ignore_zone_z"  ## deprecated
 OLD_CONF_DEBUG_CONFIG = "debug_config"  ## deprecated
 OLD_PARAM_HDZONE_SOURCES = "zone_z_sources"  ## deprecated
 OLD_PARAM_DISABLE_AUTO_QUERY = "disable_autoquery"  ## deprecated
+OLD_CONF_REPEAT_COUNT = "repeat_count"
 
 MIGRATE_CONFIG = {
     CONF_NAME: None,
@@ -66,6 +67,7 @@ MIGRATE_CONFIG = {
     OLD_CONF_IGNORE_ZONE_Z: CONF_IGNORE_HDZONE,
     OLD_PARAM_HDZONE_SOURCES: PARAM_HDZONE_SOURCES,
     OLD_PARAM_DISABLE_AUTO_QUERY: PARAM_DISABLE_AUTO_QUERY,
+    OLD_CONF_REPEAT_COUNT: PARAM_RETRY_COUNT,
 }
 
 PIONEER_OPTIONS_UPDATE = "pioneer_options_update"
@@ -84,7 +86,6 @@ OPTIONS_DEFAULTS = {
     CONF_TIMEOUT: DEFAULT_TIMEOUT,
     CONF_SOURCES: {},
     CONF_PARAMS: {},
-    CONF_REPEAT_COUNT: 4,
     CONF_IGNORE_ZONE_2: False,
     CONF_IGNORE_ZONE_3: False,
     CONF_IGNORE_HDZONE: False,

--- a/custom_components/pioneer_async/media_player.py
+++ b/custom_components/pioneer_async/media_player.py
@@ -469,7 +469,7 @@ class PioneerZone(
         async def turn_on() -> None:
             await self.pioneer.turn_on(zone=self.zone)
 
-        await self.pioneer_command(turn_on, repeat=True)
+        await self.pioneer_command(turn_on)
 
     async def async_turn_off(self) -> None:
         """Turn off media player."""
@@ -477,7 +477,7 @@ class PioneerZone(
         async def turn_off() -> None:
             await self.pioneer.turn_off(zone=self.zone)
 
-        await self.pioneer_command(turn_off, repeat=True)
+        await self.pioneer_command(turn_off)
 
     async def async_select_source(self, source: str) -> None:
         """Select input source."""
@@ -485,7 +485,7 @@ class PioneerZone(
         async def select_source() -> None:
             await self.pioneer.select_source(source=source, zone=self.zone)
 
-        await self.pioneer_command(select_source, repeat=True)
+        await self.pioneer_command(select_source)
 
     async def async_volume_up(self) -> None:
         """Volume up media player."""
@@ -555,7 +555,7 @@ class PioneerZone(
         if self.pioneer.params.get_param(PARAM_VOLUME_STEP_ONLY):
             await self.pioneer_command(set_volume_level)
         else:
-            await self.pioneer_command(set_volume_level, repeat=True)
+            await self.pioneer_command(set_volume_level)
 
     async def async_mute_volume(self, mute: bool) -> None:
         """Mute (true) or unmute (false) media player."""
@@ -566,7 +566,7 @@ class PioneerZone(
             else:
                 await self.pioneer.mute_off(zone=self.zone)
 
-        await self.pioneer_command(mute_volume, repeat=True)
+        await self.pioneer_command(mute_volume)
 
     async def async_select_sound_mode(self, sound_mode) -> None:
         """Select the sound mode."""
@@ -575,7 +575,7 @@ class PioneerZone(
             ## aiopioneer will translate sound modes
             await self.pioneer.select_listening_mode(sound_mode)
 
-        await self.pioneer_command(select_sound_mode, repeat=True)
+        await self.pioneer_command(select_sound_mode)
 
     async def async_send_command(self, service_call: ServiceCall) -> ServiceResponse:
         """Send command to the AVR."""
@@ -612,7 +612,7 @@ class PioneerZone(
         async def set_channel_levels() -> None:
             await self.pioneer.set_channel_levels(channel, level, zone=self.zone)
 
-        await self.pioneer_command(set_channel_levels, repeat=True)
+        await self.pioneer_command(set_channel_levels)
 
     async def async_set_amp_settings(self, **kwargs) -> None:
         """Set AVR amp settings."""
@@ -622,7 +622,7 @@ class PioneerZone(
         async def set_amp_settings() -> None:
             await self.pioneer.set_amp_settings(**kwargs)
 
-        await self.pioneer_command(set_amp_settings, repeat=True)
+        await self.pioneer_command(set_amp_settings)
 
     async def async_set_video_settings(self, **kwargs) -> None:
         """Set AVR video settings."""
@@ -634,7 +634,7 @@ class PioneerZone(
         async def set_video_settings() -> None:
             await self.pioneer.set_video_settings(zone=self.zone, **kwargs)
 
-        await self.pioneer_command(set_video_settings, repeat=True)
+        await self.pioneer_command(set_video_settings)
 
     async def async_set_dsp_settings(self, **kwargs) -> None:
         """Set AVR DSP settings."""
@@ -646,4 +646,4 @@ class PioneerZone(
         async def set_dsp_settings() -> None:
             await self.pioneer.set_dsp_settings(zone=self.zone, **kwargs)
 
-        await self.pioneer_command(set_dsp_settings, repeat=True)
+        await self.pioneer_command(set_dsp_settings)

--- a/custom_components/pioneer_async/number.py
+++ b/custom_components/pioneer_async/number.py
@@ -186,7 +186,7 @@ class TunerFrequencyNumber(
         async def set_tuner_frequency() -> bool:
             return await self.pioneer.set_tuner_frequency(self.band, value)
 
-        await self.pioneer_command(set_tuner_frequency, repeat=True)
+        await self.pioneer_command(set_tuner_frequency)
 
 
 class ToneNumber(PioneerEntityBase, NumberEntity):  # pylint: disable=abstract-method
@@ -238,7 +238,7 @@ class ToneTrebleNumber(
         async def set_tone_treble() -> bool:
             return await self.pioneer.set_tone_settings(zone=self.zone, treble=value)
 
-        await self.pioneer_command(set_tone_treble, repeat=True)
+        await self.pioneer_command(set_tone_treble)
 
 
 class ToneBassNumber(ToneNumber, CoordinatorEntity):  # pylint: disable=abstract-method
@@ -270,4 +270,4 @@ class ToneBassNumber(ToneNumber, CoordinatorEntity):  # pylint: disable=abstract
         async def set_tone_treble() -> bool:
             return await self.pioneer.set_tone_settings(zone=self.zone, bass=value)
 
-        await self.pioneer_command(set_tone_treble, repeat=True)
+        await self.pioneer_command(set_tone_treble)

--- a/custom_components/pioneer_async/select.py
+++ b/custom_components/pioneer_async/select.py
@@ -141,7 +141,7 @@ class TunerPresetSelect(
         async def select_tuner_preset() -> bool:
             return await self.pioneer.select_tuner_preset(tuner_class, tuner_preset)
 
-        await self.pioneer_command(select_tuner_preset, repeat=True)
+        await self.pioneer_command(select_tuner_preset)
 
 
 class TunerBandSelect(
@@ -178,7 +178,7 @@ class TunerBandSelect(
         async def select_tuner_band() -> bool:
             return await self.pioneer.select_tuner_band(TunerBand(option))
 
-        await self.pioneer_command(select_tuner_band, repeat=True)
+        await self.pioneer_command(select_tuner_band)
 
 
 class ToneModeSelect(
@@ -215,7 +215,7 @@ class ToneModeSelect(
         async def select_tone_mode() -> bool:
             return await self.pioneer.set_tone_settings(zone=self.zone, tone=option)
 
-        await self.pioneer_command(select_tone_mode, repeat=True)
+        await self.pioneer_command(select_tone_mode)
 
 
 class SpeakerSystemSelect(
@@ -266,4 +266,4 @@ class SpeakerSystemSelect(
         async def set_speaker_system() -> bool:
             return await self.pioneer.send_command("set_system_speaker_system", option)
 
-        await self.pioneer_command(set_speaker_system, repeat=True)
+        await self.pioneer_command(set_speaker_system)

--- a/custom_components/pioneer_async/strings.json
+++ b/custom_components/pioneer_async/strings.json
@@ -30,7 +30,7 @@
                     "scan_interval": "Scan interval",
                     "timeout": "Timeout",
                     "command_delay": "Command delay",
-                    "repeat_count": "Repeat action commands"
+                    "retry_count": "Retry action commands"
                 },
                 "data_description": {
                     "model": "If empty, AVR model will be queried from AVR on integration start",
@@ -39,7 +39,7 @@
                     "scan_interval": "Polling update frequency",
                     "timeout": "Connection/command timeout",
                     "command_delay": "Delay between commands sent to the AVR",
-                    "repeat_count": "Repeat action commands on failure up to the specified count"
+                    "retry_count": "Retry action commands on failure up to the specified count\n[ignore_volume_check]"
                 }
             }
         },

--- a/custom_components/pioneer_async/translations/en.json
+++ b/custom_components/pioneer_async/translations/en.json
@@ -30,7 +30,7 @@
                     "scan_interval": "Scan interval",
                     "timeout": "Timeout",
                     "command_delay": "Command delay",
-                    "repeat_count": "Repeat action commands"
+                    "retry_count": "Retry action commands"
                 },
                 "data_description": {
                     "model": "If empty, AVR model will be queried from AVR on integration start",
@@ -39,7 +39,7 @@
                     "scan_interval": "Polling update frequency",
                     "timeout": "Connection/command timeout",
                     "command_delay": "Delay between commands sent to the AVR",
-                    "repeat_count": "Repeat action commands on failure up to the specified count"
+                    "retry_count": "Retry action commands on failure up to the specified count\n[ignore_volume_check]"
                 }
             }
         },


### PR DESCRIPTION
## Breaking Changes

* The `repeat_count` option has changed to aiopioneer parameter `retry_count`.

## All Changes

* Remove command repeat count handling, deferring command retries to aiopioneer
* Migrate repeat count option to aiopioneer retry count parameter