### PR TITLE
Add auto entities for aiopioneer properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,11 @@ Not all speaker system modes are available on all AVR models. The AVR will respo
 | --- | --- | ---
 | Speaker System | select | Currently configured speaker system
 
+### Amp entities
+
+> [!NOTE]
+> The AVR does not report the current dimmer status until it is set. Thus, the dimmer select will not show a value if it has not been set since the integration last connected successfully to the AVR.
+
 ### AVR property entities
 
 The following AVR properties and property groups are available as entities where supported and reported by your AVR model. These entities can be used to display the current AVR state in dashboards, as well as be used in automation triggers and/or conditions to perform an action when an AVR property changes.

--- a/custom_components/pioneer_async/__init__.py
+++ b/custom_components/pioneer_async/__init__.py
@@ -35,7 +35,7 @@ from .config_flow import (
 )
 from .const import (
     DOMAIN,
-    PLATFORMS_CONFIG_FLOW,
+    PLATFORMS,
     MIGRATE_CONFIG,
     CONF_SOURCES,
     CONF_PARAMS,
@@ -277,7 +277,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][entry.entry_id] = pioneer_data
 
     ## Set up platforms for Pioneer AVR
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS_CONFIG_FLOW)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     async def _update_listener(hass: HomeAssistant, config_entry: ConfigEntry):
         """Handle options update."""
@@ -306,9 +306,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     pioneer.clear_zone_callbacks()
 
     ## Unload platforms for Pioneer AVR
-    unload_ok = await hass.config_entries.async_unload_platforms(
-        entry, PLATFORMS_CONFIG_FLOW
-    )
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     ## Shutdown Pioneer AVR for removal
     await pioneer.shutdown()

--- a/custom_components/pioneer_async/const.py
+++ b/custom_components/pioneer_async/const.py
@@ -21,10 +21,11 @@ from homeassistant.const import (
 )
 
 DOMAIN = "pioneer_async"
-PLATFORMS_CONFIG_FLOW = [
+PLATFORMS = [
     Platform.MEDIA_PLAYER,
     Platform.SENSOR,
     Platform.BINARY_SENSOR,
+    Platform.SWITCH,
     Platform.SELECT,
     Platform.NUMBER,
 ]

--- a/custom_components/pioneer_async/entity_base.py
+++ b/custom_components/pioneer_async/entity_base.py
@@ -48,6 +48,11 @@ class PioneerEntityBase(Entity):
     @property
     def available(self) -> bool:
         """Returns whether the AVR is available and the zone is on."""
+        return self.is_available()
+
+    def is_available(self) -> bool:
+        """Returns whether the AVR is available and the zone is on."""
+        ## NOTE: defined also as method to be directly callable from derived classes
         return self.pioneer.available and (
             self.zone is None
             or (

--- a/custom_components/pioneer_async/number.py
+++ b/custom_components/pioneer_async/number.py
@@ -1,5 +1,7 @@
 """Pioneer AVR number entities."""
 
+# pylint: disable=abstract-method
+
 from __future__ import annotations
 
 import logging
@@ -7,8 +9,9 @@ from typing import Any
 
 from aiopioneer import PioneerAVR
 from aiopioneer.const import Zone, TunerBand
+from aiopioneer.decoders.audio import ToneTreble, ToneBass
 from aiopioneer.decoders.code_map import CodeFloatMap
-from aiopioneer.decoders.tuner import FrequencyAM
+from aiopioneer.decoders.tuner import TunerAMFrequency, TunerFMFrequency
 from aiopioneer.property_entry import AVRPropertyEntry
 from aiopioneer.property_registry import get_property_entry, get_code_maps
 
@@ -34,25 +37,6 @@ from .entity_base import PioneerEntityBase, PioneerTunerEntity
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_TUNER_AM_FREQ_STEP = 9
-DEFAULT_TUNER_AM_FREQ_MIN, DEFAULT_TUNER_AM_FREQ_MAX = FrequencyAM.get_frequency_bounds(
-    DEFAULT_TUNER_AM_FREQ_STEP
-)
-TUNER_FREQ_ATTRS = {
-    TunerBand.AM: {
-        "unit_of_measurement": "kHz",
-        "min_value": DEFAULT_TUNER_AM_FREQ_MIN,
-        "max_value": DEFAULT_TUNER_AM_FREQ_MAX,
-        "step": 1,  # set once updated from AVR
-    },
-    TunerBand.FM: {
-        "unit_of_measurement": "MHz",
-        "min_value": 87.5,
-        "max_value": 108.0,
-        "step": 0.05,
-    },
-}
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -74,24 +58,15 @@ async def async_setup_entry(
     coordinator = coordinators[zone]
     entities.extend(
         [
-            TunerFrequencyNumber(
-                pioneer,
-                options,
-                coordinator=coordinator,
-                device_info=device_info,
-                band=TunerBand.FM,
+            TunerFMFrequencyNumber(
+                pioneer, options, coordinator=coordinator, device_info=device_info
             ),
-            TunerFrequencyNumber(
-                pioneer,
-                options,
-                coordinator=coordinator,
-                device_info=device_info,
-                band=TunerBand.AM,
+            TunerAMFrequencyNumber(
+                pioneer, options, coordinator=coordinator, device_info=device_info
             ),
         ]
     )
     for code_map in get_code_maps(CodeFloatMap, zone=Zone.ALL, is_ha_auto_entity=True):
-        _LOGGER.critical(code_map.__name__)
         entities.append(
             PioneerGenericNumber(
                 pioneer,
@@ -113,6 +88,7 @@ async def async_setup_entry(
                     options,
                     coordinator=coordinator,
                     device_info=device_info,
+                    property_entry=get_property_entry(ToneTreble),
                     zone=zone,
                 ),
                 ToneBassNumber(
@@ -120,32 +96,51 @@ async def async_setup_entry(
                     options,
                     coordinator=coordinator,
                     device_info=device_info,
+                    property_entry=get_property_entry(ToneBass),
                     zone=zone,
                 ),
             ]
         )
-        for code_map in get_code_maps(CodeFloatMap, zone=zone, is_ha_auto_entity=True):
-            _LOGGER.critical(code_map.__name__)
-            entities.append(
-                PioneerGenericNumber(
-                    pioneer,
-                    options,
-                    coordinator=coordinator,
-                    device_info=device_info,
-                    property_entry=get_property_entry(code_map),
-                    zone=zone,
-                )
+    for code_map in get_code_maps(CodeFloatMap, zone=zone, is_ha_auto_entity=True):
+        entities.append(
+            PioneerGenericNumber(
+                pioneer,
+                options,
+                coordinator=coordinator,
+                device_info=device_info,
+                property_entry=get_property_entry(code_map),
+                zone=zone,
             )
+        )
 
     async_add_entities(entities)
 
 
-class PioneerGenericNumber(
-    PioneerEntityBase, NumberEntity, CoordinatorEntity
-):  # pylint: disable=abstract-method
-    """Pioneer generic number entity."""
+class PioneerNumber(PioneerEntityBase, NumberEntity, CoordinatorEntity):
+    """Pioneer number base class."""
 
     _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        pioneer: PioneerAVR,
+        options: dict[str, Any],
+        coordinator: PioneerAVRZoneCoordinator,
+        device_info: DeviceInfo,
+        zone: Zone | None = None,
+    ) -> None:
+        """Initialize the Pioneer number base class."""
+        super().__init__(pioneer, options, device_info=device_info, zone=zone)
+        CoordinatorEntity.__init__(self, coordinator)
+
+    @property
+    def available(self) -> bool:
+        """Returns whether the AVR property is available."""
+        return super().available and self.native_value is not None
+
+
+class PioneerGenericNumber(PioneerNumber):
+    """Pioneer generic number entity."""
 
     def __init__(
         self,
@@ -157,6 +152,13 @@ class PioneerGenericNumber(
         zone: Zone | None = None,
     ) -> None:
         """Initialize the Pioneer generic number entity."""
+        super().__init__(
+            pioneer,
+            options,
+            coordinator=coordinator,
+            device_info=device_info,
+            zone=zone,
+        )
         self.property_entry = property_entry
         self.code_map: type[CodeFloatMap] = property_entry.code_map
         self._attr_name = self.code_map.get_ss_class_name()
@@ -174,14 +176,6 @@ class PioneerGenericNumber(
             translation_key += f"_{property_name}"
         self._attr_translation_key = translation_key
 
-        super().__init__(pioneer, options, device_info=device_info, zone=zone)
-        CoordinatorEntity.__init__(self, coordinator)
-
-    @property
-    def available(self) -> bool:
-        """Returns whether the AVR property is available."""
-        return super().available and self.native_value is not None
-
     @property
     def native_value(self) -> float | None:
         """Return the current value for the AVR property."""
@@ -195,52 +189,33 @@ class PioneerGenericNumber(
     async def async_set_native_value(self, value: float) -> None:
         """Set the AVR property."""
 
-        async def set_property() -> bool:
+        async def set_property() -> None:
             command = self.property_entry.set_command.name
-            return await self.pioneer.send_command(command, value)
+            await self.pioneer.send_command(command, value)
 
         await self.pioneer_command(set_property)
 
     async def async_update(self) -> None:
         """Refresh the AVR property."""
 
-        async def query_property() -> bool:
+        async def query_property() -> None:
             command = self.property_entry.query_command.name
-            return await self.pioneer.send_command(command)
+            await self.pioneer.send_command(command)
 
         await self.pioneer_command(query_property)
 
 
-class TunerFrequencyNumber(
-    PioneerTunerEntity, NumberEntity, CoordinatorEntity
-):  # pylint: disable=abstract-method
+class TunerFrequencyNumber(PioneerTunerEntity, PioneerNumber):
     """Pioneer tuner frequency number entity."""
 
-    _attr_entity_category = EntityCategory.CONFIG
     _attr_device_class = NumberDeviceClass.FREQUENCY
     _attr_icon = "mdi:radio-tower"
     _attr_mode = NumberMode.BOX
-    _unrecorded_attributes = frozenset({ATTR_TUNER_AM_FREQUENCY_STEP})
 
-    def __init__(
-        self,
-        pioneer: PioneerAVR,
-        options: dict[str, Any],
-        coordinator: PioneerAVRZoneCoordinator,
-        device_info: DeviceInfo,
-        band: TunerBand,
-        zone: Zone | None = None,
-    ) -> None:
-        """Initialize the Pioneer tuner frequency number entity."""
-        super().__init__(pioneer, options, device_info=device_info, zone=zone)
-        CoordinatorEntity.__init__(self, coordinator)
-        self.band = band
-        tuner_freq_attrs = TUNER_FREQ_ATTRS[band]
-        self._attr_name = f"Tuner {band} Frequency"
-        self._attr_native_unit_of_measurement = tuner_freq_attrs["unit_of_measurement"]
-        self._attr_native_min_value = tuner_freq_attrs["min_value"]
-        self._attr_native_max_value = tuner_freq_attrs["max_value"]
-        self._attr_native_step = tuner_freq_attrs["step"]
+    @property
+    def band(self) -> TunerBand:
+        """Return frequency band for entity."""
+        raise NotImplementedError
 
     @property
     def available(self) -> bool:
@@ -252,43 +227,70 @@ class TunerFrequencyNumber(
     @property
     def native_value(self) -> float | None:
         """Return the tuner frequency."""
-        return self.pioneer.properties.tuner.get("frequency")
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        """Return device specific state attributes."""
-        if self.band != TunerBand.AM:
+        if self.pioneer.properties.tuner.get("band") != self.band:
             return None
-
-        attrs = super().extra_state_attributes or {}
-        am_frequency_step = self.pioneer.properties.tuner.get("am_frequency_step")
-        if self.band is TunerBand.AM and am_frequency_step:
-            attrs |= {ATTR_TUNER_AM_FREQUENCY_STEP: am_frequency_step}
-            self._attr_native_step = am_frequency_step
-            value_min, value_max = FrequencyAM.get_frequency_bounds(am_frequency_step)
-            self._attr_native_min_value = value_min
-            self._attr_native_max_value = value_max
-        return attrs
+        return self.pioneer.properties.tuner.get("frequency")
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the tuner frequency."""
 
-        async def set_tuner_frequency() -> bool:
-            return await self.pioneer.set_tuner_frequency(self.band, value)
+        async def set_tuner_frequency() -> None:
+            await self.pioneer.set_tuner_frequency(self.band, value)
 
         await self.pioneer_command(set_tuner_frequency)
 
 
-class ToneNumber(PioneerEntityBase, NumberEntity):  # pylint: disable=abstract-method
-    """Pioneer tone number entity."""
+class TunerFMFrequencyNumber(TunerFrequencyNumber):
+    """Pioneer tuner FM frequency number entity."""
 
-    _attr_entity_category = EntityCategory.CONFIG
-    _attr_device_class = NumberDeviceClass.SIGNAL_STRENGTH
-    _attr_native_min_value = -6
-    _attr_native_max_value = 6
-    _attr_native_step = 1
-    _attr_native_unit_of_measurement = "dB"
-    _attr_mode = NumberMode.SLIDER
+    _attr_name = "Tuner FM Frequency"
+    _attr_native_unit_of_measurement = TunerFMFrequency.unit_of_measurement
+    _attr_native_min_value = TunerFMFrequency.value_min
+    _attr_native_max_value = TunerFMFrequency.value_max
+    _attr_native_step = TunerFMFrequency.value_step
+
+    @property
+    def band(self) -> TunerBand:
+        """Return frequency band for entity."""
+        return TunerBand.FM
+
+
+class TunerAMFrequencyNumber(TunerFrequencyNumber):
+    """Pioneer tuner AM frequency number entity."""
+
+    _attr_name = "Tuner AM Frequency"
+    _attr_native_unit_of_measurement = TunerAMFrequency.unit_of_measurement
+    _unrecorded_attributes = frozenset({ATTR_TUNER_AM_FREQUENCY_STEP})
+
+    @property
+    def band(self) -> TunerBand:
+        """Return frequency band for entity."""
+        return TunerBand.AM
+
+    @property
+    def native_min_value(self) -> float:
+        return TunerAMFrequency.get_frequency_bounds(self.native_step)[0]
+
+    @property
+    def native_max_value(self) -> float:
+        return TunerAMFrequency.get_frequency_bounds(self.native_step)[1]
+
+    @property
+    def native_step(self) -> float:
+        return self.pioneer.properties.tuner.get("am_frequency_step")
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return device specific state attributes."""
+        attrs = super().extra_state_attributes or {}
+
+        if am_frequency_step := self.native_step:
+            attrs |= {ATTR_TUNER_AM_FREQUENCY_STEP: am_frequency_step}
+        return attrs
+
+
+class ToneNumber(PioneerGenericNumber):
+    """Pioneer tone number entity."""
 
     @property
     def available(self) -> bool:
@@ -297,67 +299,25 @@ class ToneNumber(PioneerEntityBase, NumberEntity):  # pylint: disable=abstract-m
         return super().available and tone_status == "on"
 
 
-class ToneTrebleNumber(
-    ToneNumber, CoordinatorEntity
-):  # pylint: disable=abstract-method
+class ToneTrebleNumber(ToneNumber):
     """Pioneer tone treble number entity."""
-
-    _attr_icon = "mdi:music-clef-treble"
-    _attr_name = "Tone Treble"
-
-    def __init__(
-        self,
-        pioneer: PioneerAVR,
-        options: dict[str, Any],
-        coordinator: PioneerAVRZoneCoordinator,
-        device_info: DeviceInfo,
-        zone: Zone | None = None,
-    ) -> None:
-        """Initialize the Pioneer tone treble number entity."""
-        super().__init__(pioneer, options, device_info=device_info, zone=zone)
-        CoordinatorEntity.__init__(self, coordinator)
-
-    @property
-    def native_value(self) -> int | None:
-        """Return the tone treble value."""
-        return self.pioneer.properties.tone.get(self.zone, {}).get("treble")
 
     async def async_set_native_value(self, value: int) -> None:
         """Set the tone treble value."""
 
-        async def set_tone_treble() -> bool:
-            return await self.pioneer.set_tone_settings(zone=self.zone, treble=value)
+        async def set_tone_treble() -> None:
+            await self.pioneer.set_tone_settings(zone=self.zone, treble=value)
 
         await self.pioneer_command(set_tone_treble)
 
 
-class ToneBassNumber(ToneNumber, CoordinatorEntity):  # pylint: disable=abstract-method
+class ToneBassNumber(ToneNumber):
     """Pioneer tone bass number entity."""
-
-    _attr_icon = "mdi:music-clef-bass"
-    _attr_name = "Tone Bass"
-
-    def __init__(
-        self,
-        pioneer: PioneerAVR,
-        options: dict[str, Any],
-        coordinator: PioneerAVRZoneCoordinator,
-        device_info: DeviceInfo,
-        zone: Zone | None = None,
-    ) -> None:
-        """Initialize the Pioneer tone bass number entity."""
-        super().__init__(pioneer, options, device_info=device_info, zone=zone)
-        CoordinatorEntity.__init__(self, coordinator)
-
-    @property
-    def native_value(self) -> int | None:
-        """Return the tone bass value."""
-        return self.pioneer.properties.tone.get(self.zone, {}).get("bass")
 
     async def async_set_native_value(self, value: int) -> None:
         """Set the tone bass value."""
 
-        async def set_tone_treble() -> bool:
-            return await self.pioneer.set_tone_settings(zone=self.zone, bass=value)
+        async def set_tone_bass() -> None:
+            await self.pioneer.set_tone_settings(zone=self.zone, bass=value)
 
-        await self.pioneer_command(set_tone_treble)
+        await self.pioneer_command(set_tone_bass)

--- a/custom_components/pioneer_async/select.py
+++ b/custom_components/pioneer_async/select.py
@@ -12,6 +12,7 @@ from aiopioneer.const import Zone, TunerBand
 from aiopioneer.params import PARAM_SPEAKER_SYSTEM_MODES
 from aiopioneer.property_entry import AVRPropertyEntry
 from aiopioneer.property_registry import get_property_entry, get_code_maps
+from aiopioneer.decoders.amp import Dimmer
 from aiopioneer.decoders.code_map import CodeDictStrMap
 from aiopioneer.decoders.system import SpeakerSystem
 from aiopioneer.decoders.tuner import TunerPreset
@@ -77,6 +78,13 @@ async def async_setup_entry(
                 coordinator=coordinator,
                 device_info=device_info,
                 property_entry=get_property_entry(SpeakerSystem),
+            ),
+            DimmerSelect(
+                pioneer,
+                options,
+                coordinator=coordinator,
+                device_info=device_info,
+                property_entry=get_property_entry(Dimmer),
             ),
         ]
     )
@@ -278,3 +286,16 @@ class SpeakerSystemSelect(PioneerGenericSelect):
         return list(
             self.pioneer.params.get_param(PARAM_SPEAKER_SYSTEM_MODES, {}).values()
         )
+
+
+class DimmerSelect(PioneerGenericSelect):
+    """Pioneer dimmer select entity."""
+
+    @property
+    def available(self) -> bool:
+        """Returns whether the dimmer property is available."""
+        return PioneerEntityBase.is_available(self)
+
+    async def async_update(self) -> None:
+        """Don't refresh dimmer property as AVR command does not exist."""
+        pass

--- a/custom_components/pioneer_async/sensor.py
+++ b/custom_components/pioneer_async/sensor.py
@@ -64,7 +64,6 @@ async def async_setup_entry(
                 icon="mdi:fullscreen",
                 base_property="amp",
                 promoted_property="display",
-                include_properties=["dimmer"],
             ),
             PioneerGenericSensor(
                 pioneer,

--- a/custom_components/pioneer_async/switch.py
+++ b/custom_components/pioneer_async/switch.py
@@ -1,0 +1,153 @@
+"""Pioneer AVR switch entities."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from aiopioneer import PioneerAVR
+from aiopioneer.const import Zone
+from aiopioneer.property_entry import AVRPropertyEntry
+from aiopioneer.property_registry import get_property_entry, get_code_maps
+from aiopioneer.decoders.code_map import CodeBoolMap
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import (
+    DOMAIN,
+    ATTR_PIONEER,
+    ATTR_COORDINATORS,
+    ATTR_DEVICE_INFO,
+    ATTR_OPTIONS,
+)
+from .coordinator import PioneerAVRZoneCoordinator
+from .entity_base import PioneerEntityBase
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the switch platform."""
+    pioneer_data = hass.data[DOMAIN][config_entry.entry_id]
+    pioneer: PioneerAVR = pioneer_data[ATTR_PIONEER]
+    options: dict[str, Any] = pioneer_data[ATTR_OPTIONS]
+    coordinators: list[PioneerAVRZoneCoordinator] = pioneer_data[ATTR_COORDINATORS]
+    zone_device_info: dict[str, DeviceInfo] = pioneer_data[ATTR_DEVICE_INFO]
+    _LOGGER.debug(">> async_setup_entry(entry_id=%s)", config_entry.entry_id)
+
+    ## Add top level switches
+    entities = []
+    zone = Zone.ALL
+    device_info = zone_device_info[zone]
+    coordinator = coordinators[zone]
+    for code_map in get_code_maps(CodeBoolMap, zone=Zone.ALL, is_ha_auto_entity=True):
+        entities.append(
+            PioneerGenericSwitch(
+                pioneer,
+                options,
+                coordinator=coordinator,
+                device_info=device_info,
+                property_entry=get_property_entry(code_map),
+            )
+        )
+
+    ## Add zone specific switches
+    for zone in pioneer.properties.zones:
+        for code_map in get_code_maps(CodeBoolMap, zone=zone, is_ha_auto_entity=True):
+            entities.append(
+                PioneerGenericSwitch(
+                    pioneer,
+                    options,
+                    coordinator=coordinators[zone],
+                    device_info=zone_device_info[zone],
+                    property_entry=get_property_entry(code_map),
+                    zone=zone,
+                )
+            )
+
+    async_add_entities(entities)
+
+
+class PioneerGenericSwitch(
+    PioneerEntityBase, SwitchEntity, CoordinatorEntity
+):  # pylint: disable=abstract-method
+    """Pioneer generic switch entity."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        pioneer: PioneerAVR,
+        options: dict[str, Any],
+        coordinator: PioneerAVRZoneCoordinator,
+        device_info: DeviceInfo,
+        property_entry: AVRPropertyEntry,
+        zone: Zone | None = None,
+    ) -> None:
+        """Initialize the Pioneer generic switch entity."""
+        self.property_entry = property_entry
+        self.code_map: type[CodeBoolMap] = property_entry.code_map
+        self._attr_name = self.code_map.get_ss_class_name()
+        self._attr_icon = self.code_map.icon
+        self._attr_entity_registry_enabled_default = self.code_map.ha_enable_default
+
+        translation_key = self.code_map.base_property
+        if property_name := self.code_map.property_name:
+            translation_key += f"_{property_name}"
+        self._attr_translation_key = translation_key
+
+        super().__init__(pioneer, options, device_info=device_info, zone=zone)
+        CoordinatorEntity.__init__(self, coordinator)
+
+    @property
+    def available(self) -> bool:
+        """Returns whether the AVR property is available."""
+        return super().available and self.is_on is not None
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return whether the AVR property is on."""
+        base_value = getattr(self.pioneer.properties, self.code_map.base_property, {})
+        if self.zone is not None:
+            base_value = base_value.get(self.zone, {})
+        if self.code_map.property_name is None:
+            return base_value or None
+        return base_value.get(self.code_map.property_name)
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Turn on the AVR property."""
+
+        async def turn_on_property() -> bool:
+            command = self.property_entry.set_command.name
+            return await self.pioneer.send_command(command, True)
+
+        await self.pioneer_command(turn_on_property)
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Turn off the AVR property."""
+
+        async def turn_off_property() -> bool:
+            command = self.property_entry.set_command.name
+            return await self.pioneer.send_command(command, True)
+
+        await self.pioneer_command(turn_off_property)
+
+    async def async_update(self) -> None:
+        """Refresh the AVR property."""
+
+        async def query_property() -> bool:
+            command = self.property_entry.query_command.name
+            return await self.pioneer.send_command(command)
+
+        await self.pioneer_command(query_property)


### PR DESCRIPTION
## What's Changed
* Entities for most AVR properties are now created automatically as select, switch and number entities as appropriate for each property
  * Only properties that the AVR reports status for are available as entities. The property for unavailable entities can still be set using the AVR command `set_*` via the `send_command` command
  * The AVR dimmer property cannot be queried as there is no AVR command. However, the AVR reports dimmer status if it is set, so the dimmer entity will only show a value if has been set since the integration last successfully connected to the AVR

## Breaking Changes
* The dimmer attribute is no longer available on the Display sensor as it is now available as a separate select entity