### PR TITLE
Rename speaker_system_raw

### DIFF
--- a/custom_components/pioneer_async/sensor.py
+++ b/custom_components/pioneer_async/sensor.py
@@ -128,7 +128,7 @@ async def async_setup_entry(
                 icon="mdi:cog",
                 base_property="system",
                 promoted_property="osd_language",
-                exclude_properties=["speaker_system", "speaker_system_raw"],
+                exclude_properties=["speaker_system", "speaker_system_id"],
             ),
         ]
     )


### PR DESCRIPTION
## Breaking Changes
* The AVR parameter `speaker_system_raw` has been renamed `speaker_system_id` in `aiopioneer`. The corresponding attribute in the System property group sensor entity has also been renamed to match