### PR TITLE
Add channel level entities for supported zones

### DIFF
--- a/custom_components/pioneer_async/const.py
+++ b/custom_components/pioneer_async/const.py
@@ -110,7 +110,6 @@ CLASS_PIONEER = MediaPlayerDeviceClass.RECEIVER
 
 SERVICE_SEND_COMMAND = "send_command"
 SERVICE_SET_AMP_SETTINGS = "set_amp_settings"
-SERVICE_SET_CHANNEL_LEVELS = "set_channel_levels"
 SERVICE_SET_VIDEO_SETTINGS = "set_video_settings"
 SERVICE_SET_DSP_SETTINGS = "set_dsp_settings"
 

--- a/custom_components/pioneer_async/media_player.py
+++ b/custom_components/pioneer_async/media_player.py
@@ -36,7 +36,6 @@ from .const import (
     DOMAIN,
     CLASS_PIONEER,
     SERVICE_SEND_COMMAND,
-    SERVICE_SET_CHANNEL_LEVELS,
     SERVICE_SET_AMP_SETTINGS,
     SERVICE_SET_VIDEO_SETTINGS,
     SERVICE_SET_DSP_SETTINGS,
@@ -47,8 +46,6 @@ from .const import (
     ATTR_COMMAND,
     ATTR_PREFIX,
     ATTR_SUFFIX,
-    ATTR_CHANNEL,
-    ATTR_LEVEL,
     ATTR_AMP_SPEAKER_MODE,
     ATTR_AMP_HDMI_OUT,
     ATTR_AMP_HDMI3_OUT,
@@ -127,11 +124,6 @@ PIONEER_SEND_COMMAND_SCHEMA = {
     vol.Required(ATTR_COMMAND): cv.string,
     vol.Optional(ATTR_PREFIX): cv.string,
     vol.Optional(ATTR_SUFFIX): cv.string,
-}
-
-PIONEER_SET_CHANNEL_LEVELS_SCHEMA = {
-    vol.Required(ATTR_CHANNEL): cv.string,
-    vol.Required(ATTR_LEVEL): vol.All(vol.Coerce(float), vol.Range(min=-12, max=12)),
 }
 
 PIONEER_SET_AMP_SETTINGS_SCHEMA = {
@@ -282,11 +274,6 @@ async def async_setup_entry(
         PIONEER_SEND_COMMAND_SCHEMA,
         PioneerZone.async_send_command,
         supports_response=SupportsResponse.OPTIONAL,
-    )
-    platform.async_register_entity_service(
-        SERVICE_SET_CHANNEL_LEVELS,
-        PIONEER_SET_CHANNEL_LEVELS_SCHEMA,
-        "async_set_channel_levels",
     )
     platform.async_register_entity_service(
         SERVICE_SET_AMP_SETTINGS,
@@ -588,14 +575,6 @@ class PioneerZone(
         resp = await self.pioneer_command(send_command, command=command)
         if service_call.return_response:
             return resp
-
-    async def async_set_channel_levels(self, channel: str, level: float) -> None:
-        """Set AVR level (gain) for amplifier channel in zone."""
-
-        async def set_channel_levels() -> None:
-            await self.pioneer.set_channel_levels(channel, level, zone=self.zone)
-
-        await self.pioneer_command(set_channel_levels)
 
     async def async_set_amp_settings(self, **kwargs) -> None:
         """Set AVR amp settings."""

--- a/custom_components/pioneer_async/number.py
+++ b/custom_components/pioneer_async/number.py
@@ -332,14 +332,16 @@ class ChannelLevelNumber(PioneerGenericNumber):
             property_entry=get_property_entry(SpeakerChannelLevel),
             zone=zone,
             code_map=ChannelLevel,
-            name=f"{ChannelLevel.get_ss_class_name()} {channel}",
+            name=f"Channel {channel}",
         )
         self.channel = channel
 
     @property
     def native_value(self) -> float | None:
         """Return the level for the configured channel."""
-        return (super().native_value or {}).get(self.channel)
+        return self.pioneer.properties.channel_level.get(self.zone, {}).get(
+            self.channel
+        )
 
     async def async_set_native_value(self, value: int) -> None:
         """Set the channel level."""

--- a/custom_components/pioneer_async/select.py
+++ b/custom_components/pioneer_async/select.py
@@ -294,7 +294,9 @@ class DimmerSelect(PioneerGenericSelect):
     @property
     def available(self) -> bool:
         """Returns whether the dimmer property is available."""
-        return PioneerEntityBase.is_available(self)
+        return PioneerEntityBase.is_available(self) and any(
+            self.pioneer.properties.power.values()
+        )
 
     async def async_update(self) -> None:
         """Don't refresh dimmer property as AVR command does not exist."""

--- a/custom_components/pioneer_async/select.py
+++ b/custom_components/pioneer_async/select.py
@@ -294,9 +294,7 @@ class DimmerSelect(PioneerGenericSelect):
     @property
     def available(self) -> bool:
         """Returns whether the dimmer property is available."""
-        return PioneerEntityBase.is_available(self) and any(
-            self.pioneer.properties.power.values()
-        )
+        return PioneerEntityBase.is_available(self)
 
     async def async_update(self) -> None:
         """Don't refresh dimmer property as AVR command does not exist."""

--- a/custom_components/pioneer_async/sensor.py
+++ b/custom_components/pioneer_async/sensor.py
@@ -164,19 +164,6 @@ async def async_setup_entry(
                         promoted_property="status",  # TODO: to identify
                         exclude_properties=[],
                     ),
-                    PioneerGenericSensor(
-                        pioneer,
-                        options,
-                        coordinator=coordinator,
-                        device_info=device_info,
-                        zone=zone,
-                        name="Channel Level",
-                        icon="mdi:surround-sound",
-                        base_property="channel_levels",
-                        promoted_property="C",
-                        exclude_properties=["!C"],
-                        enabled_default=True,
-                    ),
                 ]
             )
 

--- a/custom_components/pioneer_async/services.yaml
+++ b/custom_components/pioneer_async/services.yaml
@@ -16,51 +16,6 @@ send_command:
       selector:
         text:
 
-set_channel_levels:
-  target:
-    entity:
-      integration: pioneer_async
-      domain: media_player
-  fields:
-    channel:
-      required: true
-      example: "L"
-      selector:
-        select:
-          translation_key: audio_channel_level
-          options:
-            - "L"
-            - "R"
-            - "C"
-            - "SL"
-            - "SR"
-            - "SBL"
-            - "SBR"
-            - "SW"
-            - "LH"
-            - "RH"
-            - "LW"
-            - "RW"
-            - "TML"
-            - "TMR"
-            - "TFL"
-            - "TFR"
-            - "TRL"
-            - "TRR"
-            - "SW1"
-            - "SW2"
-            - "all"
-    level:
-      required: true
-      example: 0.0
-      default: 0.0
-      selector:
-        number:
-          min: -12.0
-          max: 12.0
-          step: 0.5
-          unit_of_measurement: dB
-
 set_amp_settings:
   target:
     device:

--- a/custom_components/pioneer_async/strings.json
+++ b/custom_components/pioneer_async/strings.json
@@ -416,20 +416,6 @@
                 }
             }
         },
-        "set_channel_levels": {
-            "name": "Set Channel Levels",
-            "description": "Set AVR level (gain) for an amplifier channel.",
-            "fields": {
-                "channel": {
-                    "name": "Channel",
-                    "description": "Tuner amp channel to modify."
-                },
-                "level": {
-                    "name": "Level",
-                    "description": "Tuner amp channel level."
-                }
-            }
-        },
         "set_amp_settings": {
             "name": "Set Amp Settings",
             "description": "Set AVR settings.",

--- a/custom_components/pioneer_async/translations/en.json
+++ b/custom_components/pioneer_async/translations/en.json
@@ -416,20 +416,6 @@
                 }
             }
         },
-        "set_channel_levels": {
-            "name": "Set Channel Levels",
-            "description": "Set AVR level (gain) for an amplifier channel.",
-            "fields": {
-                "channel": {
-                    "name": "Channel",
-                    "description": "Tuner amp channel to modify."
-                },
-                "level": {
-                    "name": "Level",
-                    "description": "Tuner amp channel level."
-                }
-            }
-        },
         "set_amp_settings": {
             "name": "Set Amp Settings",
             "description": "Set AVR settings.",


### PR DESCRIPTION
## What's Changed
* Entities for channel levels for all channels on supported zones are now created. These entities are enabled by default, and those that are not available for an AVR model can be disabled. Only channels that the AVR reports status for are available to change.

## Breaking Changes
* The `channel_levels` sensor and `set_channel_levels` action have been removed. Get and change channel levels using the channel level number entities instead.