### PR TITLE
Remove unused zone AudioParameters sensor

### DIFF
--- a/custom_components/pioneer_async/sensor.py
+++ b/custom_components/pioneer_async/sensor.py
@@ -118,15 +118,6 @@ async def async_setup_entry(
                         promoted_property="resolution",
                         exclude_properties=[],
                     ),
-                    PioneerGenericSensor(
-                        pioneer_data,
-                        zone=zone,
-                        name="Audio Parameters",
-                        icon="mdi:speaker",
-                        base_property="audio",
-                        promoted_property="status",  # TODO: to identify
-                        exclude_properties=[],
-                    ),
                 ]
             )
 


### PR DESCRIPTION
## What's Changed
* The `Audio Parameters` sensor for each zone has been removed as all zone specific audio properties have separate base properties